### PR TITLE
Added ACL token support, multiple fixes 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.boundary.config</groupId>
@@ -12,20 +13,14 @@
     <url>https://github.com/boundary/archaius-consul</url>
 
     <properties>
-        <httpcomp.version>4.2.5</httpcomp.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <dependencies>
         <dependency>
             <groupId>com.netflix.archaius</groupId>
             <artifactId>archaius-core</artifactId>
-            <version>0.6.5</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.google.guava</groupId>
-                    <artifactId>guava</artifactId>
-                </exclusion>
-            </exclusions>
+            <version>0.7.1</version>
         </dependency>
 
         <dependency>
@@ -37,25 +32,13 @@
         <dependency>
             <groupId>com.ecwid.consul</groupId>
             <artifactId>consul-api</artifactId>
-            <version>1.0.6</version>
+            <version>1.1.6</version>
         </dependency>
 
         <dependency>
-            <groupId>com.google.code.gson</groupId>
-            <artifactId>gson</artifactId>
-            <version>2.3</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpcore</artifactId>
-            <version>${httpcomp.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
-            <version>${httpcomp.version}</version>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.12</version>
         </dependency>
 
         <!-- test dependencies -->
@@ -141,16 +124,8 @@
 
     <scm>
         <connection>scm:git:git@github.com:boundary/archaius-consul.git</connection>
-      <tag>HEAD</tag>
-  </scm>
-
-    <repositories>
-        <repository>
-            <id>ecwid</id>
-            <name>Ecwid</name>
-            <url>http://nexus.ecwid.com/content/groups/public</url>
-        </repository>
-    </repositories>
+        <tag>HEAD</tag>
+    </scm>
 
     <distributionManagement>
         <repository>

--- a/src/test/java/com/boundary/config/ConsulWatchedConfigurationSourceTest.java
+++ b/src/test/java/com/boundary/config/ConsulWatchedConfigurationSourceTest.java
@@ -51,7 +51,7 @@ public class ConsulWatchedConfigurationSourceTest extends RandomizedTest {
 
         final Response<List<GetValue>> expected = randomListGetValueResponse();
 
-        when(client.getKVValues(eq(rootPath), any(QueryParams.class))).thenReturn(expected);
+        when(client.getKVValues(eq(rootPath), any(String.class), any(QueryParams.class))).thenReturn(expected);
 
         assertThat(configSource.getCurrentData(), nullValue());
 
@@ -77,6 +77,7 @@ public class ConsulWatchedConfigurationSourceTest extends RandomizedTest {
 
     @Test
     @Repeat(iterations = 5)
+    @SuppressWarnings("unchecked")
     public void testAdded() throws Exception {
 
         final Response<List<GetValue>> initialResponse = randomListGetValueResponse();
@@ -84,8 +85,8 @@ public class ConsulWatchedConfigurationSourceTest extends RandomizedTest {
         final List<GetValue> updatedList = Lists.newArrayList(initialResponse.getValue());
         updatedList.add(added);
         final Response<List<GetValue>> initialResponsePlus = randomResponse(updatedList);
-        //noinspection unchecked
-        when(client.getKVValues(eq(rootPath), any(QueryParams.class))).thenReturn(initialResponse, initialResponsePlus);
+
+        when(client.getKVValues(eq(rootPath), any(String.class), any(QueryParams.class))).thenReturn(initialResponse, initialResponsePlus);
 
         UpdateListener listener = new UpdateListener();
         configSource.addUpdateListener(listener);
@@ -112,6 +113,7 @@ public class ConsulWatchedConfigurationSourceTest extends RandomizedTest {
 
     @Test
     @Repeat(iterations = 5)
+    @SuppressWarnings("unchecked")
     public void testRemoved() throws Exception {
 
         final Response<List<GetValue>> initialResponse = randomListGetValueResponse();
@@ -119,8 +121,7 @@ public class ConsulWatchedConfigurationSourceTest extends RandomizedTest {
         final List<GetValue> updatedList = Lists.newArrayList(initialResponse.getValue());
         updatedList.remove(removed);
         final Response<List<GetValue>> initialResponseMinus = randomResponse(updatedList);
-        //noinspection unchecked
-        when(client.getKVValues(eq(rootPath), any(QueryParams.class))).thenReturn(initialResponse, initialResponseMinus);
+        when(client.getKVValues(eq(rootPath), any(String.class), any(QueryParams.class))).thenReturn(initialResponse, initialResponseMinus);
 
         UpdateListener listener = new UpdateListener();
         configSource.addUpdateListener(listener);
@@ -148,6 +149,7 @@ public class ConsulWatchedConfigurationSourceTest extends RandomizedTest {
 
     @Test
     @Repeat(iterations = 5)
+    @SuppressWarnings("unchecked")
     public void testChanged() throws Exception {
 
         final Response<List<GetValue>> initialResponse = randomListGetValueResponse();
@@ -161,8 +163,7 @@ public class ConsulWatchedConfigurationSourceTest extends RandomizedTest {
         updatedList.add(changed);
 
         final Response<List<GetValue>> initialResponseChanged = randomResponse(updatedList);
-        //noinspection unchecked
-        when(client.getKVValues(eq(rootPath), any(QueryParams.class))).thenReturn(initialResponse, initialResponseChanged);
+        when(client.getKVValues(eq(rootPath), any(String.class), any(QueryParams.class))).thenReturn(initialResponse, initialResponseChanged);
 
         UpdateListener listener = new UpdateListener();
         configSource.addUpdateListener(listener);


### PR DESCRIPTION
- ACL token support
- Fixed NullPointerException when dealing with consul k/v "folders"
- Watcher sleeps a bit instead of retrying like crazy on failures when talking to Consul
- Made watcher thread a daemon thread, so it doesn't prevent JVM termination
- Bumped consul-api version
